### PR TITLE
:memo: add CONTRIBUTING and make `npm test` work on windows as well

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Setup 
+
+`npm install`
+
+# Test
+
+`npm test`

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 TypeStrong
+Copyright (c) 2015 TypeStrong
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "tsconfig.d.ts"
   ],
   "scripts": {
-    "lint": "# TODO",
+    "lint": "echo TODO",
     "build": "npm run build-ts",
     "build-ts": "rm -rf dist && tsc",
     "test-spec": "mocha dist/**/*.spec.js -R spec --bail",


### PR DESCRIPTION
@blakeembrey Mind I just start merging? I see your [release behavior](https://github.com/TypeStrong/tsconfig/releases) is much better than I ever had :rose: 

Workflow for people that aren't you (e.g. me): *Manually Create Release* per merge followed by `npm publish` from local machine?



PS seperate discussion : I'd like to swap `globby` with `node-glob` at some point. I tested `globby` with atom-typescript and it performed much slower (on ntypescript repo https://github.com/TypeStrong/ntypescript `src` folder https://github.com/TypeStrong/ntypescript/tree/master/src). I will not do that without providing measureable performance difference. We might even end up writing our own version that does prefix excludes before passing on to some third party library.