### PR TITLE
Solved issue of traversing into child directories

### DIFF
--- a/src/tsconfig.spec.ts
+++ b/src/tsconfig.spec.ts
@@ -76,7 +76,8 @@ describe('tsconfig', function () {
           join(__dirname, '../tests/exclude/included/foo.ts')
         ],
         exclude: [
-          join(__dirname, '../tests/exclude/excluded')
+          join(__dirname, '../tests/exclude/excluded'),
+          join(__dirname, '../tests/exclude/cwd.ts')
         ]
       },
       filename: join(__dirname, '../tests/exclude/tsconfig.json')

--- a/src/tsconfig.ts
+++ b/src/tsconfig.ts
@@ -192,7 +192,7 @@ function getGlob (data: TSConfig): string[] {
   const glob = data.filesGlob || ['**/*.ts', '**/*.tsx']
 
   if (Array.isArray(data.exclude)) {
-    return glob.concat(data.exclude.map(x => `!${x}{,/**/*}`))
+    return glob.concat(data.exclude.map(x => `!${x}/**`))
   }
 
   return glob

--- a/tests/exclude/tsconfig.json
+++ b/tests/exclude/tsconfig.json
@@ -8,6 +8,7 @@
     "sourceMap": true
   },
   "exclude": [
-    "excluded"
+    "excluded",
+    "cwd.ts"
   ]
 }


### PR DESCRIPTION
Read through the `node-glob` code for a bit and found that the suffix of `/**` does what we need and excludes the whole directory properly from processing (also works for files!). Might be relevant to everyone implementing `tsconfig.json` implementations, and not using this module.

Tested by logging before https://github.com/isaacs/node-glob/blob/master/glob.js#L333-L334.

**Before:**

```
. false
. false
. false
cwd.ts false
cwd.ts false
excluded false
excluded false
included false
included false
tsconfig.json false
tsconfig.json false
. false
cwd.ts false
cwd.ts false
excluded false
excluded false
included false
included false
tsconfig.json false
tsconfig.json false
excluded false
excluded/foo.ts false
excluded/foo.ts false
excluded false
excluded/foo.ts false
excluded/foo.ts false
included false
included/foo.ts false
included/foo.ts false
included false
included/foo.ts false
included/foo.ts false
```

**After:**

```
. false
. false
. false
cwd.ts true
cwd.ts true
excluded true
excluded true
included false
included false
tsconfig.json false
tsconfig.json false
. false
cwd.ts true
cwd.ts true
excluded true
excluded true
included false
included false
tsconfig.json false
tsconfig.json false
included false
included/foo.ts false
included/foo.ts false
included false
included/foo.ts false
included/foo.ts false
```

/cc @basarat 