### PR TITLE
resolve declaration file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "tsconfig",
   "version": "5.0.3",
-  "description": "Resole and parse `tsconfig.json`, replicating to TypeScript's behaviour",
+  "description": "Resolve and parse `tsconfig.json`, replicating to TypeScript's behaviour",
   "main": "dist/tsconfig.js",
+  "types": "dist/tsconfig.d.ts",
   "files": [
     "dist/",
     "LICENSE",


### PR DESCRIPTION
Hi!

This PR adds [`types`](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) to package.json so other typescript projects that uses this package can use the generated declaration file.