### PR TITLE
Allow importing types via typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.0.0",
   "description": "Resole and parse `tsconfig.json`, replicating to TypeScript's behaviour",
   "main": "dist/tsconfig.js",
+  "types": "dist/tsconfig.d.ts",
   "files": [
     "dist/",
     "LICENSE",


### PR DESCRIPTION
Without this, typescript can't see the definition files exported by this library.