### PR TITLE
do not include @types in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
   },
   "homepage": "https://github.com/TypeStrong/tsconfig",
   "dependencies": {
-    "@types/strip-bom": "^3.0.0",
-    "@types/strip-json-comments": "0.0.30",
     "strip-bom": "^3.0.0",
     "strip-json-comments": "^2.0.0"
   },
   "devDependencies": {
+    "@types/strip-bom": "^3.0.0",
+    "@types/strip-json-comments": "0.0.30",
     "@types/chai": "^4.0.4",
     "@types/mocha": "^2.2.42",
     "@types/node": "^8.0.25",

--- a/src/tsconfig.spec.ts
+++ b/src/tsconfig.spec.ts
@@ -98,6 +98,14 @@ describe('tsconfig', function () {
     }
   ]
 
+  describe('package.json', function () {
+    it('should not include @types in dependencies', function () {
+      const deps = require('../package.json').dependencies
+      // tslint:disable-next-line
+      expect(Object.keys(deps).filter((name) => /^@types\//.test(name))).to.be.empty
+    })
+  })
+
   describe('sync', function () {
     tests.forEach(function (test) {
       describe(inspect(test.args), function () {


### PR DESCRIPTION
Same reason as https://github.com/TypeStrong/ts-node/issues/475

Not a big problem as ts-node's but I don't want to install these @types for my project.