### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See the [TypeScript docs][tsconfig] for information on setting up `tsconfig.json
 * **loadSync(cwd: string, path?: string): { path?: string, config: any }** Synchronous `load`.
 * **readFile(filename: string): Promise<any>** Read a JSON file as `tsconfig.json` (strip BOM, parse JSON and support empty contents).
 * **readFileSync(filename: string): any** Synchronous `readFile`.
-* **parse(contents: string, filename: string): any** Parse file contents as `tsconfig.json` (strip BOM, parse JSON and support empty contents).
+* **parse(contents: string): any** Parse file contents as `tsconfig.json` (strip BOM, parse JSON and support empty contents).
 
 ## Contributing
 

--- a/src/tsconfig.spec.ts
+++ b/src/tsconfig.spec.ts
@@ -95,6 +95,27 @@ describe('tsconfig', function () {
         }
       },
       path: join(TEST_DIR, 'cwd/tsconfig.json')
+    },
+    {
+      args: [TEST_DIR, 'extends/tsconfig-third.json'],
+      config: {
+        compilerOptions: {
+          module: 'commonjs',
+          noImplicitAny: true,
+          outDir: 'dist-third',
+          removeComments: true,
+          sourceMap: true,
+          preserveConstEnums: true,
+          rootDirs: [
+            'src',
+            'test'
+          ]
+        },
+        files: [
+          './src/bar.ts'
+        ]
+      },
+      path: join(TEST_DIR, 'extends/tsconfig-third.json')
     }
   ]
 

--- a/src/tsconfig.ts
+++ b/src/tsconfig.ts
@@ -164,7 +164,7 @@ export function readFile (filename: string): Promise<any> {
       }
 
       try {
-        return resolve(parse(contents, filename))
+        return resolve(parse(contents))
       } catch (err) {
         return reject(err)
       }
@@ -178,13 +178,13 @@ export function readFile (filename: string): Promise<any> {
 export function readFileSync (filename: string): any {
   const contents = fs.readFileSync(filename, 'utf8')
 
-  return parse(contents, filename)
+  return parse(contents)
 }
 
 /**
  * Parse `tsconfig.json` file.
  */
-export function parse (contents: string, filename: string) {
+export function parse (contents: string) {
   const data = stripComments(stripBom(contents))
 
   // A tsconfig.json file is permitted to be completely empty.

--- a/tests/extends/tsconfig-second.json
+++ b/tests/extends/tsconfig-second.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist-second",
+        "rootDirs": [
+            "src",
+            "test"
+        ]
+    },
+    "files": [
+        "./src/bar.ts"
+    ]
+}
+

--- a/tests/extends/tsconfig-third.json
+++ b/tests/extends/tsconfig-third.json
@@ -1,0 +1,6 @@
+{
+    "extends": "./tsconfig-second.json",
+    "compilerOptions": {
+        "outDir": "dist-third"
+    }
+}

--- a/tests/extends/tsconfig.json
+++ b/tests/extends/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    // Compiler options.
+    "compilerOptions": {
+        "module": "commonjs",
+        "noImplicitAny": true,
+        "removeComments": true,
+        "preserveConstEnums": true,
+        "outDir": "dist",
+        "sourceMap": true,
+        "rootDirs": [
+            "src"
+        ]
+    },
+    // These are the files to compile with.
+    "files": [
+        "./src/foo.ts" /* Use `foo.ts` */
+    ]
+}


### PR DESCRIPTION
With this pull request we can handle "extends" at tsconfig. Multiple extends are possible too. The only thing to note is that a small part of readFile is not async cause we have to await some results.

I also removed the filename parameter from the parse method cause it was never used.

At least i've added a test with some mockups for extending tsconfig.