### PR TITLE
fix: strip dangling comma

### DIFF
--- a/tests/valid/tsconfig.json
+++ b/tests/valid/tsconfig.json
@@ -6,10 +6,12 @@
         "removeComments": true,
         "preserveConstEnums": true,
         "outDir": "dist",
-        "sourceMap": true
-    },
+        "sourceMap": true, // regular dangling comma
+    } ,
     // These are the files to compile with.
     "files": [
-        "./src/foo.ts" /* Use `foo.ts` */
+        "./src/foo.ts" /* Use `foo.ts` */ , // dangling comma surrounded with whitespace and comments
     ]
+  // dangling comma on next line
+  ,
 }


### PR DESCRIPTION
fixes #30 

note that package.json needs serious updates. 

in it's current state build fails with
```

node_modules/@types/node/index.d.ts:35:1 - error TS1084: Invalid 'reference' directive syntax.

35 /// <reference lib="es2017" />
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

the output of `npm audit` ain't pretty either.

I suggest a major update on all fronts and cutting 8.0
