### PR TITLE
Fix `invalidfile` test for Node Version 20 or higher + Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
           node-version: ${{ matrix.node }}
-          cache: 'npm'
       
       - name: Install dependencies
         run: npm i

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    timeout-minutes: 10
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [18, 20, 22]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - node: 24
+            os: ubuntu-latest
+    steps:
+      - name: Harden the runner # Inspired by https://github.com/dominikg/tsconfck
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            release-assets.githubusercontent.com:443
+            registry.npmjs.org:443
+      
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: 'false'
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm i
+      
+      - name: Build
+        run: npm run build
+      
+      - name: Lint
+        if: ${{ !cancelled() }}
+        run: npm run lint
+      
+      - name: Test with coverage
+        if: ${{ !cancelled() }}
+        run: npm run test-cov
+      
+      - name: Test specs
+        if: ${{ !cancelled() }}
+        run: npm run test-spec

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
     "strip-json-comments": "^2.0.0"
   },
   "devDependencies": {
-    "@types/chai": "^4.0.4",
+    "@types/chai": " ~4.0.4",
     "@types/mocha": "^2.2.42",
-    "@types/node": "^8.0.25",
+    "@types/node": "~8.0.25",
     "bluebird": "^3.4.1",
     "chai": "^3.0.0",
     "istanbul": "^0.4.0",

--- a/src/tsconfig.spec.ts
+++ b/src/tsconfig.spec.ts
@@ -13,10 +13,21 @@ interface Test {
 }
 
 describe('tsconfig', function () {
+  
+  const nodeMajor = Number(process.version.match(/v(\d+)/)[1]);
+  let invalidJsonError;
+  if (nodeMajor >= 20) {
+    invalidJsonError = "Unexpected token 's', \"some random string\" is not valid JSON";
+  } else if (nodeMajor >= 6) {
+    invalidJsonError = 'Unexpected token s in JSON at position 0';
+  } else {
+    invalidJsonError = 'Unexpected token s';
+  }
+
   const tests: Test[] = [
     {
       args: [TEST_DIR, 'invalidfile'],
-      error: parseInt(process.versions.node, 10) > 5 ? 'Unexpected token s in JSON at position 0' : 'Unexpected token s'
+      error: invalidJsonError
     },
     {
       args: [TEST_DIR, 'missing'],

--- a/src/tsconfig.spec.ts
+++ b/src/tsconfig.spec.ts
@@ -13,15 +13,15 @@ interface Test {
 }
 
 describe('tsconfig', function () {
-  
-  const nodeMajor = Number(process.version.match(/v(\d+)/)[1]);
-  let invalidJsonError;
+
+  const nodeMajor = Number(process.version.match(/v(\d+)/)[1])
+  let invalidJsonError
   if (nodeMajor >= 20) {
-    invalidJsonError = "Unexpected token 's', \"some random string\" is not valid JSON";
+    invalidJsonError = "Unexpected token 's', \"some random string\" is not valid JSON"
   } else if (nodeMajor >= 6) {
-    invalidJsonError = 'Unexpected token s in JSON at position 0';
+    invalidJsonError = 'Unexpected token s in JSON at position 0'
   } else {
-    invalidJsonError = 'Unexpected token s';
+    invalidJsonError = 'Unexpected token s'
   }
 
   const tests: Test[] = [


### PR DESCRIPTION
This pull request updates the `tsconfig` test suite to account for a difference in error message in Node.js version 20 or higher.

(This addresses the main issues raised in https://github.com/TypeStrong/tsconfig/pull/31#issue-961182243 in order to help better tackle https://github.com/TypeStrong/tsconfig/issues/30.)